### PR TITLE
Fixed Edge 105 release date

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -231,7 +231,7 @@
           "engine_version": "104"
         },
         "105": {
-          "release_date": "2022-08-04",
+          "release_date": "2022-09-01",
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "105"


### PR DESCRIPTION
Edge 105 is due to come out on 2022-09-01, so fixing the release date in `browsers/edge.json`